### PR TITLE
chore: fix Consumer::unsubscribeAll method

### DIFF
--- a/src/JetStream/Consumer.php
+++ b/src/JetStream/Consumer.php
@@ -20,7 +20,7 @@ use Thesis\Nats\NatsException;
  */
 final class Consumer
 {
-    /** @var array<non-empty-string, Internal\MessageHandler> */
+    /** @var array<non-empty-string|int, Internal\MessageHandler> */
     private array $subscribers = [];
 
     /**
@@ -137,7 +137,7 @@ final class Consumer
     public function unsubscribeAll(): void
     {
         foreach ($this->subscribers as $sid => $messageHandler) {
-            $this->nats->unsubscribe($sid);
+            $this->nats->unsubscribe((string) $sid);
             unset($this->subscribers[$sid]);
 
             $messageHandler->stop();

--- a/tests/JetStreamTest.php
+++ b/tests/JetStreamTest.php
@@ -823,4 +823,109 @@ final class JetStreamTest extends NatsTestCase
 
         $stream->delete();
     }
+
+    public function testConsumerUnsubscribeAll(): void
+    {
+        $client = $this->client();
+        $js = $client->jetStream();
+
+        $subject = generateUniqueId(10);
+        $streamName = generateUniqueId(10);
+
+        $stream = $js->createStream(new StreamConfig(
+            name: $streamName,
+            subjects: ["{$subject}.*"]
+        ));
+
+        $consumer = $stream->createConsumer(new ConsumerConfig(
+            durableName: generateUniqueId(10),
+            ackPolicy: AckPolicy::Explicit
+        ));
+
+        $iterator1 = $consumer->consume();
+        $iterator2 = $consumer->consume();
+        $iterator3 = $consumer->consume();
+
+        $reflection = new \ReflectionClass($consumer);
+        $subscribersProperty = $reflection->getProperty('subscribers');
+        $subscribersProperty->setAccessible(true);
+        $subscribers = $subscribersProperty->getValue($consumer);
+
+        self::assertCount(3, $subscribers);
+
+        $consumer->unsubscribeAll();
+
+        $subscribersAfter = $subscribersProperty->getValue($consumer);
+        self::assertCount(0, $subscribersAfter);
+
+        $stream->delete();
+    }
+
+    public function testConsumerUnsubscribeAllWithNoSubscriptions(): void
+    {
+        $client = $this->client();
+        $js = $client->jetStream();
+
+        $streamName = generateUniqueId(10);
+
+        $stream = $js->createStream(new StreamConfig($streamName));
+
+        $consumer = $stream->createConsumer(new ConsumerConfig(
+            durableName: generateUniqueId(10),
+            ackPolicy: AckPolicy::Explicit
+        ));
+
+        $consumer->unsubscribeAll();
+
+        $reflection = new \ReflectionClass($consumer);
+        $subscribersProperty = $reflection->getProperty('subscribers');
+        $subscribersProperty->setAccessible(true);
+        $subscribers = $subscribersProperty->getValue($consumer);
+
+        self::assertCount(0, $subscribers);
+
+        $stream->delete();
+    }
+
+    public function testConsumerUnsubscribeAllStopsMessageHandlers(): void
+    {
+        $client = $this->client();
+        $js = $client->jetStream();
+
+        $subject = generateUniqueId(10);
+        $streamName = generateUniqueId(10);
+
+        $stream = $js->createStream(new StreamConfig(
+            name: $streamName,
+            subjects: ["{$subject}.*"]
+        ));
+
+        $consumer = $stream->createConsumer(new ConsumerConfig(
+            durableName: generateUniqueId(10),
+            ackPolicy: AckPolicy::Explicit
+        ));
+
+        $iterator = $consumer->consume();
+
+        $reflection = new \ReflectionClass($consumer);
+        $subscribersProperty = $reflection->getProperty('subscribers');
+        $subscribersProperty->setAccessible(true);
+        $subscribers = $subscribersProperty->getValue($consumer);
+
+        self::assertCount(1, $subscribers);
+        $messageHandler = array_values($subscribers)[0];
+
+        $messageHandlerReflection = new \ReflectionClass($messageHandler);
+        $queueProperty = $messageHandlerReflection->getProperty('queue');
+        $queueProperty->setAccessible(true);
+        $queue = $queueProperty->getValue($messageHandler);
+
+        self::assertFalse($queue->isComplete());
+
+        $consumer->unsubscribeAll();
+
+        self::assertTrue($queue->isComplete());
+
+        $stream->delete();
+    }
 }

--- a/tests/JetStreamTest.php
+++ b/tests/JetStreamTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Thesis\Nats;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use Thesis\Nats\Exception\ConsumerDoesNotExist;
 use Thesis\Nats\Exception\ConsumerNotFound;
 use Thesis\Nats\Exception\StreamDoesNotMatch;
@@ -844,31 +845,15 @@ final class JetStreamTest extends NatsTestCase
             ackPolicy: AckPolicy::Explicit
         ));
 
-        $iterator1 = $consumer->consume();
-        $iterator2 = $consumer->consume();
-        $iterator3 = $consumer->consume();
-        
-        $completed = [];
-        
-        $futures = [
-            async(function () use ($iterator1, &$completed): void {
-                foreach ($iterator1 as $_) {
-                }
-                $completed[] = 'iterator1';
-            }),
-            
-            async(function () use ($iterator2, &$completed): void {
-                foreach ($iterator2 as $_) {
-                }
-                $completed[] = 'iterator2';
-            }),
-            
-            async(function () use ($iterator3, &$completed): void {
-                foreach ($iterator3 as $_) {
-                }
-                $completed[] = 'iterator3';
-            })
-        ];
+        $completedCount = 0;
+        $futures = [];
+
+        for ($i = 0; $i < 3; ++$i) {
+            $futures[] = async(static function () use ($consumer, &$completedCount): void {
+                foreach ($consumer->consume() as $_) {}
+                $completedCount++;
+            });
+        }
 
         delay(0.01);
         
@@ -876,50 +861,12 @@ final class JetStreamTest extends NatsTestCase
         
         awaitAll($futures);
         
-        self::assertCount(3, $completed, 'All iterators should complete after unsubscribeAll');
+        self::assertSame(3, $completedCount, 'All iterators should complete after unsubscribeAll');
 
         $stream->delete();
     }
 
-    public function testConsumerUnsubscribeAllWithSingleSubscription(): void
-    {
-        $client = $this->client();
-        $js = $client->jetStream();
-
-        $subject = generateUniqueId(10);
-        $streamName = generateUniqueId(10);
-
-        $stream = $js->createStream(new StreamConfig(
-            name: $streamName,
-            subjects: ["{$subject}.*"]
-        ));
-
-        $consumer = $stream->createConsumer(new ConsumerConfig(
-            durableName: generateUniqueId(10),
-            ackPolicy: AckPolicy::Explicit
-        ));
-
-        $iterator = $consumer->consume();
-        
-        $completed = false;
-        
-        $future = async(function () use ($iterator, &$completed): void {
-            foreach ($iterator as $_) {
-            }
-            $completed = true;
-        });
-
-        delay(0.01);
-        
-        $consumer->unsubscribeAll();
-        
-        awaitAll([$future]);
-        
-        self::assertTrue($completed, 'Iterator should complete after unsubscribeAll');
-
-        $stream->delete();
-    }
-    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+    #[DoesNotPerformAssertions]
     public function testConsumerUnsubscribeAllWithNoSubscriptions(): void
     {
         $client = $this->client();

--- a/tests/JetStreamTest.php
+++ b/tests/JetStreamTest.php
@@ -29,7 +29,9 @@ use Thesis\Nats\JetStream\Api\ConsumerInfo;
 use Thesis\Nats\JetStream\Api\DeliverPolicy;
 use Thesis\Nats\JetStream\Api\StreamConfig;
 use Thesis\Time\TimeSpan;
+use function Amp\async;
 use function Amp\delay;
+use function Amp\Future\awaitAll;
 use function Amp\now;
 use function Thesis\Nats\Internal\Id\generateUniqueId;
 
@@ -845,49 +847,41 @@ final class JetStreamTest extends NatsTestCase
         $iterator1 = $consumer->consume();
         $iterator2 = $consumer->consume();
         $iterator3 = $consumer->consume();
+        
+        $completed = [];
+        
+        $futures = [
+            async(function () use ($iterator1, &$completed): void {
+                foreach ($iterator1 as $_) {
+                }
+                $completed[] = 'iterator1';
+            }),
+            
+            async(function () use ($iterator2, &$completed): void {
+                foreach ($iterator2 as $_) {
+                }
+                $completed[] = 'iterator2';
+            }),
+            
+            async(function () use ($iterator3, &$completed): void {
+                foreach ($iterator3 as $_) {
+                }
+                $completed[] = 'iterator3';
+            })
+        ];
 
-        $reflection = new \ReflectionClass($consumer);
-        $subscribersProperty = $reflection->getProperty('subscribers');
-        $subscribersProperty->setAccessible(true);
-        $subscribers = $subscribersProperty->getValue($consumer);
-
-        self::assertCount(3, $subscribers);
-
+        delay(0.01);
+        
         $consumer->unsubscribeAll();
-
-        $subscribersAfter = $subscribersProperty->getValue($consumer);
-        self::assertCount(0, $subscribersAfter);
+        
+        awaitAll($futures);
+        
+        self::assertCount(3, $completed, 'All iterators should complete after unsubscribeAll');
 
         $stream->delete();
     }
 
-    public function testConsumerUnsubscribeAllWithNoSubscriptions(): void
-    {
-        $client = $this->client();
-        $js = $client->jetStream();
-
-        $streamName = generateUniqueId(10);
-
-        $stream = $js->createStream(new StreamConfig($streamName));
-
-        $consumer = $stream->createConsumer(new ConsumerConfig(
-            durableName: generateUniqueId(10),
-            ackPolicy: AckPolicy::Explicit
-        ));
-
-        $consumer->unsubscribeAll();
-
-        $reflection = new \ReflectionClass($consumer);
-        $subscribersProperty = $reflection->getProperty('subscribers');
-        $subscribersProperty->setAccessible(true);
-        $subscribers = $subscribersProperty->getValue($consumer);
-
-        self::assertCount(0, $subscribers);
-
-        $stream->delete();
-    }
-
-    public function testConsumerUnsubscribeAllStopsMessageHandlers(): void
+    public function testConsumerUnsubscribeAllWithSingleSubscription(): void
     {
         $client = $this->client();
         $js = $client->jetStream();
@@ -906,25 +900,41 @@ final class JetStreamTest extends NatsTestCase
         ));
 
         $iterator = $consumer->consume();
+        
+        $completed = false;
+        
+        $future = async(function () use ($iterator, &$completed): void {
+            foreach ($iterator as $_) {
+            }
+            $completed = true;
+        });
 
-        $reflection = new \ReflectionClass($consumer);
-        $subscribersProperty = $reflection->getProperty('subscribers');
-        $subscribersProperty->setAccessible(true);
-        $subscribers = $subscribersProperty->getValue($consumer);
+        delay(0.01);
+        
+        $consumer->unsubscribeAll();
+        
+        awaitAll([$future]);
+        
+        self::assertTrue($completed, 'Iterator should complete after unsubscribeAll');
 
-        self::assertCount(1, $subscribers);
-        $messageHandler = array_values($subscribers)[0];
+        $stream->delete();
+    }
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+    public function testConsumerUnsubscribeAllWithNoSubscriptions(): void
+    {
+        $client = $this->client();
+        $js = $client->jetStream();
 
-        $messageHandlerReflection = new \ReflectionClass($messageHandler);
-        $queueProperty = $messageHandlerReflection->getProperty('queue');
-        $queueProperty->setAccessible(true);
-        $queue = $queueProperty->getValue($messageHandler);
+        $streamName = generateUniqueId(10);
 
-        self::assertFalse($queue->isComplete());
+        $stream = $js->createStream(new StreamConfig($streamName));
+
+        $consumer = $stream->createConsumer(new ConsumerConfig(
+            durableName: generateUniqueId(10),
+            ackPolicy: AckPolicy::Explicit
+        ));
 
         $consumer->unsubscribeAll();
-
-        self::assertTrue($queue->isComplete());
 
         $stream->delete();
     }

--- a/tests/JetStreamTest.php
+++ b/tests/JetStreamTest.php
@@ -837,12 +837,12 @@ final class JetStreamTest extends NatsTestCase
 
         $stream = $js->createStream(new StreamConfig(
             name: $streamName,
-            subjects: ["{$subject}.*"]
+            subjects: ["{$subject}.*"],
         ));
 
         $consumer = $stream->createConsumer(new ConsumerConfig(
             durableName: generateUniqueId(10),
-            ackPolicy: AckPolicy::Explicit
+            ackPolicy: AckPolicy::Explicit,
         ));
 
         $completedCount = 0;
@@ -850,17 +850,17 @@ final class JetStreamTest extends NatsTestCase
 
         for ($i = 0; $i < 3; ++$i) {
             $futures[] = async(static function () use ($consumer, &$completedCount): void {
-                foreach ($consumer->consume() as $_) {}
-                $completedCount++;
+                foreach ($consumer->consume() as $_);
+                ++$completedCount;
             });
         }
 
         delay(0.01);
-        
+
         $consumer->unsubscribeAll();
-        
+
         awaitAll($futures);
-        
+
         self::assertSame(3, $completedCount, 'All iterators should complete after unsubscribeAll');
 
         $stream->delete();
@@ -878,7 +878,7 @@ final class JetStreamTest extends NatsTestCase
 
         $consumer = $stream->createConsumer(new ConsumerConfig(
             durableName: generateUniqueId(10),
-            ackPolicy: AckPolicy::Explicit
+            ackPolicy: AckPolicy::Explicit,
         ));
 
         $consumer->unsubscribeAll();


### PR DESCRIPTION
Numeric string keys in PHP associative arrays are converted to int: `private array $subscribers = [];` 
As a result, when  
```
foreach ($this->subscribers as $sid => $messageHandler) {
          $this->nats->unsubscribe($sid) ...;
```
is called, an **int** key is passed to $sid and an error occurs : Argument 1 ($sid) must be of type string, int given.
This fix resolves the issue.