### PR TITLE
Refactor JetStream Consumer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,13 @@ $stream = $js->createStream(new StreamConfig(
     subjects: ['events.*'],
 ));
 
-$logConsumer = $stream->createConsumer(new ConsumerConfig(
-    durableName: 'EventLog',
-    ackPolicy: AckPolicy::None,
-));
+$logConsumer = $stream
+    ->createConsumer(new ConsumerConfig(
+        durableName: 'EventLog',
+        ackPolicy: AckPolicy::None,
+    ))
+    ->asPull()
+    ;
 
 $logSubscription = $logConsumer->consume(
     static function (Nats\JetStream\Delivery $delivery): void {
@@ -197,10 +200,13 @@ $logSubscription = $logConsumer->consume(
     ),
 );
 
-$handleConsumer = $stream->createConsumer(new ConsumerConfig(
-    durableName: 'EventHandle',
-    ackPolicy: AckPolicy::Explicit,
-));
+$handleConsumer = $stream
+    ->createConsumer(new ConsumerConfig(
+        durableName: 'EventHandle',
+        ackPolicy: AckPolicy::Explicit,
+    ))
+    ->asPull()
+    ;
 
 $handleSubscription = $handleConsumer->consume(
     static function (Nats\JetStream\Delivery $delivery): void {
@@ -543,12 +549,15 @@ $js->publish('scheduler.recurrents.1', new Nats\Message(
         ->with(Header\ScheduleTarget::header(), 'recurrents'),
 ));
 
-$consumer = $stream->createOrUpdateConsumer(new ConsumerConfig(
-    durableName: 'RecurrentsConsumer',
-    deliverPolicy: DeliverPolicy::New,
-    ackPolicy: AckPolicy::None,
-    filterSubjects: ['recurrents'],
-));
+$consumer = $stream
+    ->createOrUpdateConsumer(new ConsumerConfig(
+        durableName: 'RecurrentsConsumer',
+        deliverPolicy: DeliverPolicy::New,
+        ackPolicy: AckPolicy::None,
+        filterSubjects: ['recurrents'],
+    ))
+    ->asPull()
+    ;
 
 $consumer->consume(static function (Nats\JetStream\Delivery $delivery): void {
     dump([

--- a/README.md
+++ b/README.md
@@ -182,42 +182,36 @@ $stream = $js->createStream(new StreamConfig(
     subjects: ['events.*'],
 ));
 
-$logConsumer = $stream
+$logSubscription = $stream
     ->createConsumer(new ConsumerConfig(
         durableName: 'EventLog',
         ackPolicy: AckPolicy::None,
     ))
-    ->asPull()
-    ;
+    ->pull(
+        static function (Nats\JetStream\Delivery $delivery): void {
+            dump("Log event with ack=none: {$delivery->message->payload} ({$delivery->subject})");
+        },
+        new ConsumeConfig(
+            batch: 10,
+            heartbeat: TimeSpan::fromSeconds(5),
+        ),
+    );
 
-$logSubscription = $logConsumer->consume(
-    static function (Nats\JetStream\Delivery $delivery): void {
-        dump("Log event with ack=none: {$delivery->message->payload} ({$delivery->subject})");
-    },
-    new ConsumeConfig(
-        batch: 10,
-        heartbeat: TimeSpan::fromSeconds(5),
-    ),
-);
-
-$handleConsumer = $stream
+$handleSubscription = $stream
     ->createConsumer(new ConsumerConfig(
         durableName: 'EventHandle',
         ackPolicy: AckPolicy::Explicit,
     ))
-    ->asPull()
-    ;
-
-$handleSubscription = $handleConsumer->consume(
-    static function (Nats\JetStream\Delivery $delivery): void {
-        dump("Handle event with ack=explicit: {$delivery->message->payload} ({$delivery->subject})");
-        $delivery->ack();
-    },
-    new ConsumeConfig(
-        batch: 10,
-        heartbeat: TimeSpan::fromSeconds(5),
-    ),
-);
+    ->pull(
+        static function (Nats\JetStream\Delivery $delivery): void {
+            dump("Handle event with ack=explicit: {$delivery->message->payload} ({$delivery->subject})");
+            $delivery->ack();
+        },
+        new ConsumeConfig(
+            batch: 10,
+            heartbeat: TimeSpan::fromSeconds(5),
+        ),
+    );
 
 for ($i = 0; $i < 10; ++$i) {
     $js->publish(
@@ -529,6 +523,7 @@ use Thesis\Nats\JetStream\Api\AckPolicy;
 use Thesis\Nats\JetStream\Api\ConsumerConfig;
 use Thesis\Nats\JetStream\Api\StreamConfig;
 use Thesis\Nats\JetStream\Api\DeliverPolicy;
+use function Amp\trapSignal;
 
 $nc = new Nats\Client(Nats\Config::default());
 $js = $nc->jetStream();
@@ -549,23 +544,24 @@ $js->publish('scheduler.recurrents.1', new Nats\Message(
         ->with(Header\ScheduleTarget::header(), 'recurrents'),
 ));
 
-$consumer = $stream
+$subscription = $stream
     ->createOrUpdateConsumer(new ConsumerConfig(
         durableName: 'RecurrentsConsumer',
         deliverPolicy: DeliverPolicy::New,
         ackPolicy: AckPolicy::None,
         filterSubjects: ['recurrents'],
     ))
-    ->asPull()
-    ;
+    ->pull(static function (Nats\JetStream\Delivery $delivery): void {
+        dump([
+            $delivery->message->payload,
+            $delivery->message->headers?->get(Header\Scheduler::header()),
+            $delivery->message->headers?->get(Header\ScheduleNext::header()),
+        ]);
+    });
 
-$consumer->consume(static function (Nats\JetStream\Delivery $delivery): void {
-    dump([
-        $delivery->message->payload,
-        $delivery->message->headers?->get(Header\Scheduler::header()),
-        $delivery->message->headers?->get(Header\ScheduleNext::header()),
-    ]);
-});
+trapSignal([\SIGINT, \SIGTERM]);
+
+$subscription->awaitCompletion();
 ```
 
 ## NATS JetStream Batch Publishing

--- a/examples/jetstream/consume.php
+++ b/examples/jetstream/consume.php
@@ -21,7 +21,9 @@ $stream = $js->createStream(new Api\StreamConfig(
     subjects: ['events.*'],
 ));
 
-$consumer = $stream->createConsumer(new Api\ConsumerConfig(durableName: 'EventsConsumer', ackPolicy: Api\AckPolicy::Explicit));
+$consumer = $stream
+    ->createConsumer(new Api\ConsumerConfig(durableName: 'EventsConsumer', ackPolicy: Api\AckPolicy::Explicit))
+    ->asPull();
 
 $subscription = $consumer->consume(
     static function (Nats\JetStream\Delivery $delivery): void {

--- a/examples/jetstream/consume.php
+++ b/examples/jetstream/consume.php
@@ -21,11 +21,9 @@ $stream = $js->createStream(new Api\StreamConfig(
     subjects: ['events.*'],
 ));
 
-$consumer = $stream
-    ->createConsumer(new Api\ConsumerConfig(durableName: 'EventsConsumer', ackPolicy: Api\AckPolicy::Explicit))
-    ->asPull();
+$consumer = $stream->createConsumer(new Api\ConsumerConfig(durableName: 'EventsConsumer', ackPolicy: Api\AckPolicy::Explicit));
 
-$subscription = $consumer->consume(
+$subscription = $consumer->pull(
     static function (Nats\JetStream\Delivery $delivery): void {
         dump($delivery->message->payload);
         $delivery->ack();

--- a/src/JetStream.php
+++ b/src/JetStream.php
@@ -210,7 +210,7 @@ final readonly class JetStream
      */
     public function pullConsumer(string $stream, string $consumer): JetStream\PullConsumer
     {
-        return $this->consumer($stream, $consumer)->asPull();
+        return $this->consumer($stream, $consumer)->pulling();
     }
 
     /**

--- a/src/JetStream.php
+++ b/src/JetStream.php
@@ -205,15 +205,33 @@ final readonly class JetStream
 
     /**
      * @param non-empty-string $stream
+     * @param non-empty-string $consumer
+     * @throws NatsException
+     */
+    public function pullConsumer(string $stream, string $consumer): JetStream\PullConsumer
+    {
+        return $this->consumer($stream, $consumer)->asPull();
+    }
+
+    /**
+     * @param non-empty-string $stream
+     * @param non-empty-string $consumer
+     * @throws NatsException
+     */
+    public function consumer(string $stream, string $consumer): JetStream\Consumer
+    {
+        return $this->setupConsumer($this->consumerInfo($stream, $consumer));
+    }
+
+    /**
+     * @param non-empty-string $stream
      * @throws NatsException
      */
     public function createConsumer(
         string $stream,
         Api\ConsumerConfig $config = new Api\ConsumerConfig(),
     ): JetStream\Consumer {
-        return $this->setupConsumer(
-            $this->upsertConsumer($stream, $config, Api\CreateConsumerRequest::ACTION_CREATE),
-        );
+        return $this->upsertConsumer($stream, $config, Api\CreateConsumerRequest::ACTION_CREATE);
     }
 
     /**
@@ -223,7 +241,7 @@ final readonly class JetStream
     public function updateConsumer(
         string $stream,
         Api\ConsumerConfig $config = new Api\ConsumerConfig(),
-    ): Api\ConsumerInfo {
+    ): JetStream\Consumer {
         return $this->upsertConsumer($stream, $config, Api\CreateConsumerRequest::ACTION_UPDATE);
     }
 
@@ -235,9 +253,7 @@ final readonly class JetStream
         string $stream,
         Api\ConsumerConfig $config = new Api\ConsumerConfig(),
     ): JetStream\Consumer {
-        return $this->setupConsumer(
-            $this->upsertConsumer($stream, $config),
-        );
+        return $this->upsertConsumer($stream, $config);
     }
 
     /**
@@ -639,7 +655,7 @@ final readonly class JetStream
      * @param ?Api\CreateConsumerRequest::ACTION_* $action
      * @throws NatsException
      */
-    private function upsertConsumer(string $stream, Api\ConsumerConfig $config, ?string $action = null): Api\ConsumerInfo
+    private function upsertConsumer(string $stream, Api\ConsumerConfig $config, ?string $action = null): JetStream\Consumer
     {
         $consumerName = $config->name ?? $config->durableName;
 
@@ -647,20 +663,20 @@ final readonly class JetStream
             $consumerName = Id\generateUniqueId(10);
         }
 
-        return $this->request(new Api\CreateConsumerRequest(
+        $info = $this->request(new Api\CreateConsumerRequest(
             stream: $stream,
             consumer: $consumerName,
             config: $config,
             action: $action,
         ));
+
+        return $this->setupConsumer($info);
     }
 
     private function setupConsumer(Api\ConsumerInfo $info): JetStream\Consumer
     {
         return new JetStream\Consumer(
             info: $info,
-            name: $info->name,
-            stream: $info->streamName,
             js: $this,
             nats: $this->nats,
             router: $this->router,

--- a/src/JetStream/Consumer.php
+++ b/src/JetStream/Consumer.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Thesis\Nats\JetStream;
 
+use Amp\Cancellation;
 use Thesis\Nats\Client;
 use Thesis\Nats\JetStream;
 use Thesis\Nats\JetStream\Api\Router;
 use Thesis\Nats\Json\Encoder;
 use Thesis\Nats\NatsException;
+use Thesis\Nats\Subscription;
 
 /**
  * @api
@@ -32,7 +34,7 @@ final readonly class Consumer
         $this->stream = $info->streamName;
     }
 
-    public function asPull(): PullConsumer
+    public function pulling(): PullConsumer
     {
         return new PullConsumer(
             info: $this->info,
@@ -40,6 +42,20 @@ final readonly class Consumer
             router: $this->router,
             json: $this->json,
         );
+    }
+
+    /**
+     * @param callable(Delivery, Subscription): void $handler
+     * @throws NatsException
+     */
+    public function pull(
+        callable $handler,
+        ConsumeConfig $config = new ConsumeConfig(),
+        ?Cancellation $cancellation = null,
+    ): Subscription {
+        return $this
+            ->pulling()
+            ->consume($handler, $config, $cancellation);
     }
 
     /**

--- a/src/JetStream/Consumer.php
+++ b/src/JetStream/Consumer.php
@@ -4,36 +4,43 @@ declare(strict_types=1);
 
 namespace Thesis\Nats\JetStream;
 
-use Amp\Cancellation;
 use Thesis\Nats\Client;
-use Thesis\Nats\Internal\Id;
 use Thesis\Nats\JetStream;
 use Thesis\Nats\JetStream\Api\Router;
 use Thesis\Nats\Json\Encoder;
 use Thesis\Nats\NatsException;
-use Thesis\Nats\Subscription;
 
 /**
  * @api
  */
-final class Consumer
+final readonly class Consumer
 {
-    /** @var list<Subscription> */
-    private array $subscribers = [];
+    /** @var non-empty-string */
+    public string $name;
 
-    /**
-     * @param non-empty-string $name
-     * @param non-empty-string $stream
-     */
+    /** @var non-empty-string */
+    public string $stream;
+
     public function __construct(
-        public readonly Api\ConsumerInfo $info,
-        public readonly string $name,
-        public readonly string $stream,
-        private readonly JetStream $js,
-        private readonly Client $nats,
-        private readonly Router $router,
-        private readonly Encoder $json,
-    ) {}
+        public Api\ConsumerInfo $info,
+        private JetStream $js,
+        private Client $nats,
+        private Router $router,
+        private Encoder $json,
+    ) {
+        $this->name = $info->name;
+        $this->stream = $info->streamName;
+    }
+
+    public function asPull(): PullConsumer
+    {
+        return new PullConsumer(
+            info: $this->info,
+            nats: $this->nats,
+            router: $this->router,
+            json: $this->json,
+        );
+    }
 
     /**
      * @throws NatsException
@@ -41,39 +48,6 @@ final class Consumer
     public function actualInfo(): Api\ConsumerInfo
     {
         return $this->js->consumerInfo($this->stream, $this->name);
-    }
-
-    /**
-     * @param callable(Delivery, Subscription): void $handler
-     * @throws NatsException
-     */
-    public function consume(
-        callable $handler,
-        ConsumeConfig $config = new ConsumeConfig(),
-        ?Cancellation $cancellation = null,
-    ): Subscription {
-        $id = Id\generateInboxId();
-
-        $messageHandler = new Internal\MessageHandler(
-            handler: $handler,
-            nats: $this->nats,
-            json: $this->json,
-            config: $config,
-            subject: $this->router->route(Api\ApiMethod::ConsumerMessageNext->compile($this->stream, $this->name)),
-            replyTo: $id,
-        );
-
-        $subscription = $this->nats->subscribe(
-            subject: $id,
-            handler: $messageHandler,
-            cancellation: $cancellation,
-        );
-
-        $this->subscribers[] = $subscription->onComplete(
-            $messageHandler->stop(...),
-        );
-
-        return $subscription;
     }
 
     /**
@@ -121,14 +95,5 @@ final class Consumer
             consumer: $this->name,
             group: $group,
         );
-    }
-
-    public function unsubscribeAll(?Cancellation $cancellation = null): void
-    {
-        [$subscribers, $this->subscribers] = [$this->subscribers, []];
-
-        foreach ($subscribers as $subscriber) {
-            $subscriber->stop($cancellation);
-        }
     }
 }

--- a/src/JetStream/Counter/CounterStore.php
+++ b/src/JetStream/Counter/CounterStore.php
@@ -85,19 +85,17 @@ final readonly class CounterStore
             $subjects,
         );
 
-        $consumer = $this->stream
-            ->createOrUpdateConsumer(new Api\ConsumerConfig(
-                deliverPolicy: DeliverPolicy::LastPerSubject,
-                ackPolicy: AckPolicy::None,
-                replayPolicy: ReplayPolicy::Instant,
-                filterSubjects: $subjects,
-            ))
-            ->asPull();
+        $consumer = $this->stream->createOrUpdateConsumer(new Api\ConsumerConfig(
+            deliverPolicy: DeliverPolicy::LastPerSubject,
+            ackPolicy: AckPolicy::None,
+            replayPolicy: ReplayPolicy::Instant,
+            filterSubjects: $subjects,
+        ));
 
         /** @var Pipeline\Queue<Entry> $queue */
         $queue = new Pipeline\Queue($buffer = 1_000);
 
-        $consumer->consume(
+        $consumer->pull(
             function (JetStream\Delivery $delivery, Subscription $subscription) use ($queue): void {
                 if ($delivery->message->headers?->statusCode() === Status::NoMessages) {
                     $queue->complete();

--- a/src/JetStream/Counter/CounterStore.php
+++ b/src/JetStream/Counter/CounterStore.php
@@ -85,12 +85,14 @@ final readonly class CounterStore
             $subjects,
         );
 
-        $consumer = $this->stream->createOrUpdateConsumer(new Api\ConsumerConfig(
-            deliverPolicy: DeliverPolicy::LastPerSubject,
-            ackPolicy: AckPolicy::None,
-            replayPolicy: ReplayPolicy::Instant,
-            filterSubjects: $subjects,
-        ));
+        $consumer = $this->stream
+            ->createOrUpdateConsumer(new Api\ConsumerConfig(
+                deliverPolicy: DeliverPolicy::LastPerSubject,
+                ackPolicy: AckPolicy::None,
+                replayPolicy: ReplayPolicy::Instant,
+                filterSubjects: $subjects,
+            ))
+            ->asPull();
 
         /** @var Pipeline\Queue<Entry> $queue */
         $queue = new Pipeline\Queue($buffer = 1_000);

--- a/src/JetStream/Internal/PullMessageHandler.php
+++ b/src/JetStream/Internal/PullMessageHandler.php
@@ -17,6 +17,7 @@ use Thesis\Time\TimeSpan;
 
 /**
  * @internal
+ * @TODO Consider for future refactoring:
  */
 final readonly class PullMessageHandler
 {

--- a/src/JetStream/Internal/PullMessageHandler.php
+++ b/src/JetStream/Internal/PullMessageHandler.php
@@ -67,16 +67,17 @@ final readonly class PullMessageHandler
             return;
         }
 
-        ($this->handler)(
-            new JetStreamDelivery(
+        if (\in_array($statusCode ?? Status::OK, [Status::OK, Status::NoMessages], true)) {
+            $jsDelivery = new JetStreamDelivery(
                 message: $delivery->message,
                 subject: $delivery->subject,
                 acks: $this->acks,
                 metadata: $delivery->replyTo !== null ? Metadata::parse($delivery->replyTo) : null,
                 replyTo: $delivery->replyTo,
-            ),
-            $subscription,
-        );
+            );
+
+            ($this->handler)($jsDelivery, $subscription);
+        }
 
         $this->heartbeats->reset();
         $this->pulls->request();

--- a/src/JetStream/Internal/PullMessageHandler.php
+++ b/src/JetStream/Internal/PullMessageHandler.php
@@ -18,7 +18,7 @@ use Thesis\Time\TimeSpan;
 /**
  * @internal
  */
-final readonly class MessageHandler
+final readonly class PullMessageHandler
 {
     private Acks $acks;
 

--- a/src/JetStream/PullConsumer.php
+++ b/src/JetStream/PullConsumer.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Thesis\Nats\JetStream;
 
 use Amp\Cancellation;
+use Amp\Future;
 use Thesis\Nats\Client;
 use Thesis\Nats\Internal\Id;
 use Thesis\Nats\JetStream\Api\Router;
 use Thesis\Nats\Json\Encoder;
 use Thesis\Nats\NatsException;
 use Thesis\Nats\Subscription;
+use function Amp\async;
 
 /**
  * @api
@@ -60,12 +62,30 @@ final class PullConsumer
         return $subscription;
     }
 
-    public function unsubscribeAll(?Cancellation $cancellation = null): void
+    public function stop(?Cancellation $cancellation = null): void
+    {
+        $this->complete(static fn(Subscription $subscription) => $subscription->stop($cancellation));
+    }
+
+    public function drain(?Cancellation $cancellation = null): void
+    {
+        $this->complete(static fn(Subscription $subscription) => $subscription->drain($cancellation));
+    }
+
+    /**
+     * @param \Closure(Subscription): void $complete
+     */
+    private function complete(\Closure $complete): void
     {
         [$subscribers, $this->subscribers] = [$this->subscribers, []];
 
+        /** @var list<Future<void>> $futures */
+        $futures = [];
+
         foreach ($subscribers as $subscriber) {
-            $subscriber->stop($cancellation);
+            $futures[] = async($complete, $subscriber);
         }
+
+        Future\awaitAll($futures);
     }
 }

--- a/src/JetStream/PullConsumer.php
+++ b/src/JetStream/PullConsumer.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Thesis\Nats\JetStream;
+
+use Amp\Cancellation;
+use Thesis\Nats\Client;
+use Thesis\Nats\Internal\Id;
+use Thesis\Nats\JetStream\Api\Router;
+use Thesis\Nats\Json\Encoder;
+use Thesis\Nats\NatsException;
+use Thesis\Nats\Subscription;
+
+/**
+ * @api
+ */
+final class PullConsumer
+{
+    /** @var list<Subscription> */
+    private array $subscribers = [];
+
+    public function __construct(
+        private readonly Api\ConsumerInfo $info,
+        private readonly Client $nats,
+        private readonly Router $router,
+        private readonly Encoder $json,
+    ) {}
+
+    /**
+     * @param callable(Delivery, Subscription): void $handler
+     * @throws NatsException
+     */
+    public function consume(
+        callable $handler,
+        ConsumeConfig $config = new ConsumeConfig(),
+        ?Cancellation $cancellation = null,
+    ): Subscription {
+        $id = Id\generateInboxId();
+
+        $messageHandler = new Internal\PullMessageHandler(
+            handler: $handler,
+            nats: $this->nats,
+            json: $this->json,
+            config: $config,
+            subject: $this->router->route(Api\ApiMethod::ConsumerMessageNext->compile($this->info->streamName, $this->info->name)),
+            replyTo: $id,
+        );
+
+        $subscription = $this->nats->subscribe(
+            subject: $id,
+            handler: $messageHandler,
+            cancellation: $cancellation,
+        );
+
+        $this->subscribers[] = $subscription->onComplete(
+            $messageHandler->stop(...),
+        );
+
+        return $subscription;
+    }
+
+    public function unsubscribeAll(?Cancellation $cancellation = null): void
+    {
+        [$subscribers, $this->subscribers] = [$this->subscribers, []];
+
+        foreach ($subscribers as $subscriber) {
+            $subscriber->stop($cancellation);
+        }
+    }
+}

--- a/src/JetStream/PullConsumer.php
+++ b/src/JetStream/PullConsumer.php
@@ -20,7 +20,7 @@ use function Amp\async;
 final class PullConsumer
 {
     /** @var list<Subscription> */
-    private array $subscribers = [];
+    private array $subscriptions = [];
 
     public function __construct(
         private readonly Api\ConsumerInfo $info,
@@ -55,7 +55,7 @@ final class PullConsumer
             cancellation: $cancellation,
         );
 
-        $this->subscribers[] = $subscription->onComplete(
+        $this->subscriptions[] = $subscription->onComplete(
             $messageHandler->stop(...),
         );
 
@@ -77,13 +77,13 @@ final class PullConsumer
      */
     private function complete(\Closure $complete): void
     {
-        [$subscribers, $this->subscribers] = [$this->subscribers, []];
+        [$subscriptions, $this->subscriptions] = [$this->subscriptions, []];
 
         /** @var list<Future<void>> $futures */
         $futures = [];
 
-        foreach ($subscribers as $subscriber) {
-            $futures[] = async($complete, $subscriber);
+        foreach ($subscriptions as $subscription) {
+            $futures[] = async($complete, $subscription);
         }
 
         Future\awaitAll($futures);

--- a/src/JetStream/Stream.php
+++ b/src/JetStream/Stream.php
@@ -62,11 +62,37 @@ final readonly class Stream
     }
 
     /**
+     * @param non-empty-string $consumer
+     * @throws NatsException
+     */
+    public function pullConsumer(string $consumer): PullConsumer
+    {
+        return $this->js->pullConsumer($this->name, $consumer);
+    }
+
+    /**
+     * @param non-empty-string $consumer
+     * @throws NatsException
+     */
+    public function consumer(string $consumer): Consumer
+    {
+        return $this->js->consumer($this->name, $consumer);
+    }
+
+    /**
      * @throws NatsException
      */
     public function createConsumer(Api\ConsumerConfig $config = new Api\ConsumerConfig()): Consumer
     {
         return $this->js->createConsumer($this->name, $config);
+    }
+
+    /**
+     * @throws NatsException
+     */
+    public function updateConsumer(Api\ConsumerConfig $config = new Api\ConsumerConfig()): Consumer
+    {
+        return $this->js->updateConsumer($this->name, $config);
     }
 
     /**

--- a/tests/JetStreamTest.php
+++ b/tests/JetStreamTest.php
@@ -864,7 +864,7 @@ final class JetStreamTest extends NatsTestCase
 
         delay(0.01);
 
-        $consumer->unsubscribeAll();
+        $consumer->stop();
 
         awaitAll(array_map(static fn(Subscription $subscription): Future => async($subscription->awaitCompletion(...)), $subscriptions));
 
@@ -890,7 +890,7 @@ final class JetStreamTest extends NatsTestCase
             ))
             ->pulling();
 
-        $consumer->unsubscribeAll();
+        $consumer->stop();
 
         $stream->delete();
     }

--- a/tests/JetStreamTest.php
+++ b/tests/JetStreamTest.php
@@ -231,7 +231,7 @@ final class JetStreamTest extends NatsTestCase
 
         $consumer = $stream->createConsumer(new ConsumerConfig(durableName: $consumerName, ackPolicy: AckPolicy::Explicit));
 
-        self::assertSame($consumerName, $consumer->info->name);
+        self::assertSame($consumerName, $consumer->name);
         self::assertSame(AckPolicy::Explicit, $consumer->info->config->ackPolicy);
         self::assertSame(0, $consumer->info->numPending);
 
@@ -249,14 +249,14 @@ final class JetStreamTest extends NatsTestCase
 
         $consumerName = generateUniqueId(10);
 
-        $consumer = $js->createConsumer($stream, new ConsumerConfig(durableName: $consumerName, ackPolicy: AckPolicy::Explicit));
+        $createdConsumer = $js->createConsumer($stream, new ConsumerConfig(durableName: $consumerName, ackPolicy: AckPolicy::Explicit));
 
-        $updatedInfo = $js->updateConsumer($stream, new ConsumerConfig(durableName: $consumerName, description: 'Test Consumer', ackPolicy: AckPolicy::Explicit));
+        $updatedConsumer = $js->updateConsumer($stream, new ConsumerConfig(durableName: $consumerName, description: 'Test Consumer', ackPolicy: AckPolicy::Explicit));
 
-        self::assertSame($consumer->info->config->durableName, $updatedInfo->config->durableName);
-        self::assertSame($consumer->info->config->ackPolicy, $updatedInfo->config->ackPolicy);
-        self::assertNull($consumer->info->config->description);
-        self::assertSame('Test Consumer', $updatedInfo->config->description);
+        self::assertSame($createdConsumer->info->config->durableName, $updatedConsumer->info->config->durableName);
+        self::assertSame($createdConsumer->info->config->ackPolicy, $updatedConsumer->info->config->ackPolicy);
+        self::assertNull($createdConsumer->info->config->description);
+        self::assertSame('Test Consumer', $updatedConsumer->info->config->description);
 
         $js->deleteStream($stream);
     }
@@ -669,7 +669,7 @@ final class JetStreamTest extends NatsTestCase
         $counter = 0;
         $messages = [];
 
-        $subscription = $consumer->consume(static function (JetStreamDelivery $delivery, Subscription $subscription) use (
+        $subscription = $consumer->asPull()->consume(static function (JetStreamDelivery $delivery, Subscription $subscription) use (
             &$messages,
             &$counter,
         ): void {
@@ -817,7 +817,7 @@ final class JetStreamTest extends NatsTestCase
         ));
 
         $ts = now();
-        $subscription = $consumer->consume(static function (JetStreamDelivery $delivery, Subscription $subscription) use ($ts): void {
+        $subscription = $consumer->asPull()->consume(static function (JetStreamDelivery $delivery, Subscription $subscription) use ($ts): void {
             self::assertTrue(now() - $ts > 0.5);
             self::assertSame('{"id":1}', $delivery->message->payload);
             self::assertNotNull($delivery->message->headers);
@@ -844,10 +844,12 @@ final class JetStreamTest extends NatsTestCase
             subjects: ["{$subject}.*"],
         ));
 
-        $consumer = $stream->createConsumer(new ConsumerConfig(
-            durableName: generateUniqueId(10),
-            ackPolicy: AckPolicy::Explicit,
-        ));
+        $consumer = $stream
+            ->createConsumer(new ConsumerConfig(
+                durableName: generateUniqueId(10),
+                ackPolicy: AckPolicy::Explicit,
+            ))
+            ->asPull();
 
         $completedCount = 0;
         $subscriptions = [];
@@ -881,10 +883,12 @@ final class JetStreamTest extends NatsTestCase
 
         $stream = $js->createStream(new StreamConfig($streamName));
 
-        $consumer = $stream->createConsumer(new ConsumerConfig(
-            durableName: generateUniqueId(10),
-            ackPolicy: AckPolicy::Explicit,
-        ));
+        $consumer = $stream
+            ->createConsumer(new ConsumerConfig(
+                durableName: generateUniqueId(10),
+                ackPolicy: AckPolicy::Explicit,
+            ))
+            ->asPull();
 
         $consumer->unsubscribeAll();
 

--- a/tests/JetStreamTest.php
+++ b/tests/JetStreamTest.php
@@ -669,7 +669,7 @@ final class JetStreamTest extends NatsTestCase
         $counter = 0;
         $messages = [];
 
-        $subscription = $consumer->asPull()->consume(static function (JetStreamDelivery $delivery, Subscription $subscription) use (
+        $subscription = $consumer->pull(static function (JetStreamDelivery $delivery, Subscription $subscription) use (
             &$messages,
             &$counter,
         ): void {
@@ -817,7 +817,7 @@ final class JetStreamTest extends NatsTestCase
         ));
 
         $ts = now();
-        $subscription = $consumer->asPull()->consume(static function (JetStreamDelivery $delivery, Subscription $subscription) use ($ts): void {
+        $subscription = $consumer->pull(static function (JetStreamDelivery $delivery, Subscription $subscription) use ($ts): void {
             self::assertTrue(now() - $ts > 0.5);
             self::assertSame('{"id":1}', $delivery->message->payload);
             self::assertNotNull($delivery->message->headers);
@@ -849,7 +849,7 @@ final class JetStreamTest extends NatsTestCase
                 durableName: generateUniqueId(10),
                 ackPolicy: AckPolicy::Explicit,
             ))
-            ->asPull();
+            ->pulling();
 
         $completedCount = 0;
         $subscriptions = [];
@@ -888,7 +888,7 @@ final class JetStreamTest extends NatsTestCase
                 durableName: generateUniqueId(10),
                 ackPolicy: AckPolicy::Explicit,
             ))
-            ->asPull();
+            ->pulling();
 
         $consumer->unsubscribeAll();
 


### PR DESCRIPTION
Since **pull** and **push** represent the message consumption model, there is no need to mention it in the consumer management API (for instance, having a `createConsumer` method is sufficient instead of `createPullConsumer`). The method should return a `Consumer` object, which serves as an interface to the consumer's state on the NATS side. The consumption method — pull or push — is only chosen when we are ready to read messages.

In other words, we can write the following for a **pull** consumer:
```php
$subscription = $stream
     ->consumer('logreader')
     ->pull(function (JetStream\Delivery $delivery): void {});
```

Or the following for a **push** consumer:
```php
$subscription = $stream
     ->consumer('logreader')
     ->push(function (JetStream\Delivery $delivery): void {});
```

If you need to scale message consumption for a single consumer within one process, you can use the following approach:

```php
$consumer = $stream
     ->consumer('logreader')
     ->pulling();

$consumer->consume(function (JetStream\Delivery $delivery): void {});
$consumer->consume(function (JetStream\Delivery $delivery): void {});

// ... await signals or other trigger

$consumer->drain();
```