### PR TITLE
Made the Delivery object lightweight

### DIFF
--- a/src/JetStream/Internal/Acks.php
+++ b/src/JetStream/Internal/Acks.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Thesis\Nats\JetStream\Internal;
 
 use Amp\Cancellation;
-use Thesis\Nats\Client;
+use Thesis\Nats\Delivery;
 use Thesis\Nats\Message;
-use Thesis\Nats\NatsException;
 use Thesis\Time\TimeSpan;
 
 /**
@@ -15,59 +14,66 @@ use Thesis\Time\TimeSpan;
  */
 final readonly class Acks
 {
+    /**
+     * @param \Closure(non-empty-string, Message, ?Cancellation=): void $publish
+     * @param \Closure(non-empty-string, Message, ?Cancellation=): Delivery $request
+     */
     public function __construct(
-        private Client $nats,
+        private \Closure $publish,
+        private \Closure $request,
     ) {}
 
     /**
      * @param non-empty-string $replyTo
-     * @throws NatsException
      */
     public function ack(string $replyTo, bool $sync = false, ?Cancellation $cancellation = null): void
     {
         $handler = match ($sync) {
-            true => $this->nats->request(...),
-            default => $this->nats->publish(...),
+            true => $this->request,
+            default => $this->publish,
         };
 
-        $handler($replyTo, new Message('+ACK'), cancellation: $cancellation);
+        $handler(
+            $replyTo,
+            new Message('+ACK'),
+            $cancellation,
+        );
     }
 
     /**
      * @param non-empty-string $replyTo
-     * @throws NatsException
      */
     public function nack(string $replyTo, ?TimeSpan $delay = null, ?Cancellation $cancellation = null): void
     {
-        $body = '-NAK';
-        if ($delay !== null) {
-            $body .= \sprintf(' {"delay": %d}', $delay->toNanoseconds());
-        }
-
-        $this->nats->publish($replyTo, new Message($body), cancellation: $cancellation);
+        ($this->publish)(
+            $replyTo,
+            new Message('-NAK' . ($delay !== null ? \sprintf(' {"delay": %d}', $delay->toNanoseconds()) : '')),
+            $cancellation,
+        );
     }
 
     /**
      * @param non-empty-string $replyTo
-     * @throws NatsException
      */
     public function inProgress(string $replyTo, ?Cancellation $cancellation = null): void
     {
-        $this->nats->publish($replyTo, new Message('+WPI'), cancellation: $cancellation);
+        ($this->publish)(
+            $replyTo,
+            new Message('+WPI'),
+            $cancellation,
+        );
     }
 
     /**
      * @param non-empty-string $replyTo
      * @param ?non-empty-string $reason
-     * @throws NatsException
      */
     public function terminate(string $replyTo, ?string $reason = null, ?Cancellation $cancellation = null): void
     {
-        $body = '+TERM';
-        if ($reason !== null) {
-            $body .= " {$reason}";
-        }
-
-        $this->nats->publish($replyTo, new Message($body), cancellation: $cancellation);
+        ($this->publish)(
+            $replyTo,
+            new Message('+TERM' . ($reason !== null ? " {$reason}" : '')),
+            $cancellation,
+        );
     }
 }

--- a/src/JetStream/Internal/PullMessageHandler.php
+++ b/src/JetStream/Internal/PullMessageHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Thesis\Nats\JetStream\Internal;
 
+use Amp\Cancellation;
 use Thesis\Nats\Client;
 use Thesis\Nats\Delivery as NatsDelivery;
 use Thesis\Nats\Description;
@@ -11,13 +12,14 @@ use Thesis\Nats\JetStream\ConsumeConfig;
 use Thesis\Nats\JetStream\Delivery as JetStreamDelivery;
 use Thesis\Nats\JetStream\Metadata;
 use Thesis\Nats\Json\Encoder;
+use Thesis\Nats\Message;
 use Thesis\Nats\Status;
 use Thesis\Nats\Subscription;
 use Thesis\Time\TimeSpan;
 
 /**
  * @internal
- * @TODO Consider for future refactoring:
+ * @TODO Consider for future refactoring
  */
 final readonly class PullMessageHandler
 {
@@ -40,7 +42,14 @@ final readonly class PullMessageHandler
         string $subject,
         string $replyTo,
     ) {
-        $this->acks = new Acks($nats);
+        $this->acks = new Acks(
+            static fn(string $subject, Message $message, ?Cancellation $cancellation = null) => $nats->publish(
+                $subject,
+                $message,
+                cancellation: $cancellation,
+            ),
+            $nats->request(...),
+        );
         $this->heartbeats = new Heartbeat\Monitor(
             interval: $config->heartbeat ?? TimeSpan::fromSeconds(-1),
         );

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Thesis\Nats;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Thesis\Nats\JetStream\Api\AckPolicy;
+use Thesis\Nats\JetStream\Api\ConsumerConfig;
+use Thesis\Nats\JetStream\Api\StreamConfig;
+use Thesis\Nats\JetStream\Consumer;
+use Thesis\Nats\JetStream\Delivery as JetStreamDelivery;
+use Thesis\Time\TimeSpan;
+use function Thesis\Nats\Internal\Id\generateUniqueId;
+
+#[CoversClass(Consumer::class)]
+final class ConsumerTest extends NatsTestCase
+{
+    public function testAckDelivery(): void
+    {
+        $nc = $this->client();
+        $js = $nc->jetStream();
+
+        $subject = generateUniqueId(10);
+        $streamName = generateUniqueId(10);
+
+        $stream = $js->createStream(new StreamConfig(
+            name: $streamName,
+            subjects: ["{$subject}.*"],
+        ));
+
+        $js->publish("{$subject}.x", new Message('x'));
+
+        $consumer = $stream->createConsumer(
+            new ConsumerConfig(durableName: generateUniqueId(10), ackPolicy: AckPolicy::Explicit),
+        );
+
+        self::assertSame(1, $consumer->actualInfo()->numPending);
+
+        $subscription = $consumer->pull(static function (JetStreamDelivery $delivery, Subscription $subscription): void {
+            $delivery->ack();
+            $subscription->stop();
+        });
+
+        $subscription->awaitCompletion();
+
+        self::assertSame(0, $consumer->actualInfo()->numPending);
+        self::assertSame(0, $consumer->actualInfo()->numRedelivered);
+
+        $stream->delete();
+    }
+
+    public function testNackDelivery(): void
+    {
+        $nc = $this->client();
+        $js = $nc->jetStream();
+
+        $subject = generateUniqueId(10);
+        $streamName = generateUniqueId(10);
+
+        $stream = $js->createStream(new StreamConfig(
+            name: $streamName,
+            subjects: ["{$subject}.*"],
+        ));
+
+        $js->publish("{$subject}.x", new Message('x'));
+
+        $consumer = $stream->createConsumer(
+            new ConsumerConfig(durableName: generateUniqueId(10), ackPolicy: AckPolicy::Explicit),
+        );
+
+        self::assertSame(1, $consumer->actualInfo()->numPending);
+
+        $subscription = $consumer->pull(static function (JetStreamDelivery $delivery, Subscription $subscription): void {
+            $delivery->nack();
+            $subscription->stop();
+        });
+
+        $subscription->awaitCompletion();
+
+        self::assertSame(0, $consumer->actualInfo()->numPending);
+        self::assertSame(1, $consumer->actualInfo()->numRedelivered);
+
+        $stream->delete();
+    }
+
+    public function testNackWithDelayDelivery(): void
+    {
+        $nc = $this->client();
+        $js = $nc->jetStream();
+
+        $subject = generateUniqueId(10);
+        $streamName = generateUniqueId(10);
+
+        $stream = $js->createStream(new StreamConfig(
+            name: $streamName,
+            subjects: ["{$subject}.*"],
+        ));
+
+        $js->publish("{$subject}.x", new Message('x'));
+
+        $consumer = $stream->createConsumer(
+            new ConsumerConfig(durableName: generateUniqueId(10), ackPolicy: AckPolicy::Explicit),
+        );
+
+        self::assertSame(1, $consumer->actualInfo()->numPending);
+
+        $count = 0;
+
+        $subscription = $consumer->pull(static function (JetStreamDelivery $delivery, Subscription $subscription) use (&$count): void {
+            ++$count;
+
+            if ($count > 1) {
+                $delivery->terminate('unprocessable');
+                $subscription->stop();
+            } else {
+                $delivery->nack(TimeSpan::fromMilliseconds(200));
+            }
+        });
+
+        $subscription->awaitCompletion();
+
+        self::assertSame(2, $count);
+        self::assertSame(0, $consumer->actualInfo()->numPending);
+        self::assertSame(0, $consumer->actualInfo()->numRedelivered);
+
+        $stream->delete();
+    }
+}


### PR DESCRIPTION
Closes #38 

Previously, the `JetStream\Delivery` object depended on `Acks`, which internally contained an `Nats\Client` with all its dependencies. This made the object quite heavy, and simple debugging (like using `var_dump`) resulted in enormous output. The `Acks` class has now been refactored to accept two closures instead: one for sending a request and another for publishing a message. Additionally, tests for **ack**, **nack** and **terminate** have been added.