### PR TITLE
Add optional TTL parameter to Bucket::put() method

### DIFF
--- a/src/JetStream/KeyValue/Bucket.php
+++ b/src/JetStream/KeyValue/Bucket.php
@@ -71,10 +71,19 @@ final readonly class Bucket
      * @param non-empty-string $key
      * @return non-negative-int
      */
-    public function put(string $key, ?string $value = null): int
+    public function put(string $key, ?string $value = null, ?TimeSpan $ttl = null): int
     {
+        if ($ttl !== null) {
+            $headers = (new Headers())->with(Header\MsgTtl::Header, $ttl);
+        } else {
+            $headers = null;
+        }
+
         return $this->js
-            ->publish($this->prefixedSubject($key), new Message($value))
+            ->publish($this->prefixedSubject($key), new Message(
+                payload: $value,
+                headers: $headers,
+            ))
             ->seq ?? throw new \LogicException('Sequence expected on kv publish');
     }
 


### PR DESCRIPTION
Add optional TTL parameter to `KeyValue\Bucket::put()` method.
Previously, there was no way to specify a TTL when storing values.